### PR TITLE
Fix bug that filledness is always 2

### DIFF
--- a/bot/src/evaluation/standard.rs
+++ b/bot/src/evaluation/standard.rs
@@ -445,11 +445,11 @@ fn covered_cells(board: &Board) -> (i32, i32) {
 fn sky_tslot(board: &Board) -> Option<(i32, i32)> {
     fn filledness(board: &Board, x: i32, y: i32) -> usize {
         let mut filled = 0;
-        for cy in y-1..y+1 {
+        'yloop: for cy in y-1..y+1 {
             for rx in 0..10 {
                 if rx < x-1 || rx > x+1 {
                     if !board.occupied(rx, cy) {
-                        break
+                        continue 'yloop;
                     }
                 }
             }


### PR DESCRIPTION
When `break` is reached in `filledness()`, the inner loop ends. so `filled += 1;` is always executed regardless of the board. I thought this was not intended and fixed it.