### PR TITLE
Give C API access to placement plans

### DIFF
--- a/c-api/coldclear.h
+++ b/c-api/coldclear.h
@@ -33,7 +33,7 @@ typedef enum CCBotPollStatus {
     CC_BOT_DEAD
 } CCBotPollStatus;
 
-typedef struct CCPlan {
+typedef struct CCPlanPlacement {
     CCPiece piece;
     CCTspinStatus tspin;
 
@@ -41,9 +41,9 @@ typedef struct CCPlan {
     uint8_t expected_x[4];
     uint8_t expected_y[4];
 
-    /* Expected lines that will be cleared after placement. 0 being the bottom line, and -1 being not cleared */
+    /* Expected lines that will be cleared after placement, with -1 indicating no line */
     int32_t cleared_lines[4];
-} CCPlan;
+} CCPlanPlacement;
 
 typedef struct CCMove {
     /* Whether hold is required */
@@ -177,26 +177,33 @@ void cc_request_next_move(CCAsyncBot *bot, uint32_t incoming);
  * If the piece couldn't be placed in the expected location, you must call `cc_reset_async` to
  * reset the game field, back-to-back status, and combo values.
  * 
- * If plans is not null, caller is responsible for allocating space for array of CCPlan.
- * The num_plans parameter is used for both input and output. Caller passes in the size of
- * the allocated array, this function returns the number of plans actually provided.
+ * If `plan` and `plan_length` are not `NULL` and this function provides a move, a placement plan
+ * will be returned in the array pointed to by `plan`. `plan_length` should point to the length
+ * of the array, and the number of plan placements provided will be returned through this pointer.
  * 
  * If the move has been provided, this function will return `CC_MOVE_PROVIDED`.
  * If the bot has not produced a result, this function will return `CC_WAITING`.
  * If the bot has found that it cannot survive, this function will return `CC_BOT_DEAD`
  */
-CCBotPollStatus cc_poll_next_move(CCAsyncBot *bot, CCMove *move, CCPlan* plans, uint32_t *num_plans);
+CCBotPollStatus cc_poll_next_move(
+    CCAsyncBot *bot,
+    CCMove *move,
+    CCPlanPlacement* plan,
+    uint32_t *plan_length
+);
 
 /* This function is the same as `cc_poll_next_move` except when `cc_poll_next_move` would return
  * `CC_WAITING` it instead waits until the bot has made a decision.
- * If plans is not null, caller is responsible for allocating space for array of CCPlan.
- * The num_plans parameter is used for both input and output. Caller passes in the size of
- * the allocated array, this function returns the number of plans actually provided.
  *
  * If the move has been provided, this function will return `CC_MOVE_PROVIDED`.
  * If the bot has found that it cannot survive, this function will return `CC_BOT_DEAD`
  */
-CCBotPollStatus cc_block_next_move(CCAsyncBot *bot, CCMove *move, CCPlan* plans, uint32_t *num_plans);
+CCBotPollStatus cc_block_next_move(
+    CCAsyncBot *bot,
+    CCMove *move,
+    CCPlanPlacement* plan,
+    uint32_t *plan_length
+);
 
 /* Returns the default options in the options parameter */
 void cc_default_options(CCOptions *options);

--- a/c-api/coldclear.h
+++ b/c-api/coldclear.h
@@ -16,7 +16,6 @@ typedef enum CCTspinStatus {
     CC_NONE_TSPIN_STATUS,
     CC_MINI,
     CC_FULL,
-    CC_PERSISTENT_FULL
 } CCTspinStatus;
 
 typedef enum CCMovement {
@@ -208,33 +207,26 @@ void cc_request_next_move(CCAsyncBot *bot, uint32_t incoming);
  * If the piece couldn't be placed in the expected location, you must call `cc_reset_async` to
  * reset the game field, back-to-back status, and combo values.
  * 
+ * If plans is not null, caller is responsible for allocating space for array of CCPlan.
+ * The num_plans parameter is used for both input and output. Caller passes in the size of
+ * the allocated array, this function returns the number of plans actually provided.
+ * 
  * If the move has been provided, this function will return `CC_MOVE_PROVIDED`.
  * If the bot has not produced a result, this function will return `CC_WAITING`.
  * If the bot has found that it cannot survive, this function will return `CC_BOT_DEAD`
  */
-CCBotPollStatus cc_poll_next_move(CCAsyncBot *bot, CCMove *move);
-
-/* Same to cc_poll_next_move_with_plans, but also provide plans along with the next move.
- * Caller is responsible for allocating space for array of CCPlan.
- * The num_plans parameter is used for both input and output. Caller passes in the size of
- * the allocated array, this function returns the number of plans actually provided.
- */
-CCBotPollStatus cc_poll_next_move_with_plans(CCAsyncBot *bot, CCMove *move, CCPlan* plans, uint32_t *num_plans);
+CCBotPollStatus cc_poll_next_move(CCAsyncBot *bot, CCMove *move, CCPlan* plans, uint32_t *num_plans);
 
 /* This function is the same as `cc_poll_next_move` except when `cc_poll_next_move` would return
  * `CC_WAITING` it instead waits until the bot has made a decision.
+ * If plans is not null, caller is responsible for allocating space for array of CCPlan.
+ * The num_plans parameter is used for both input and output. Caller passes in the size of
+ * the allocated array, this function returns the number of plans actually provided.
  *
  * If the move has been provided, this function will return `CC_MOVE_PROVIDED`.
  * If the bot has found that it cannot survive, this function will return `CC_BOT_DEAD`
  */
-CCBotPollStatus cc_block_next_move(CCAsyncBot *bot, CCMove *move);
-
-/* Same to cc_block_next_move, but also provide plans along with the next move.
- * Caller is responsible for allocating space for array of CCPlan.
- * The num_plans parameter is used for both input and output. Caller passes in the size of
- * the allocated array, this function returns the number of plans actually provided.
- */
-CCBotPollStatus cc_block_next_move_with_plans(CCAsyncBot *bot, CCMove *move, CCPlan* plans, uint32_t *num_plans);
+CCBotPollStatus cc_block_next_move(CCAsyncBot *bot, CCMove *move, CCPlan* plans, uint32_t *num_plans);
 
 /* Returns the default options in the options parameter */
 void cc_default_options(CCOptions *options);

--- a/c-api/coldclear.h
+++ b/c-api/coldclear.h
@@ -8,16 +8,6 @@ typedef enum CCPiece {
     CC_I, CC_T, CC_O, CC_S, CC_Z, CC_L, CC_J
 } CCPiece;
 
-typedef enum CCRotationState {
-    CC_NORTH, CC_SOUTH, CC_EAST, CC_WEST
-} CCRotationState;
-
-typedef enum CCTspinStatus {
-    CC_NONE_TSPIN_STATUS,
-    CC_MINI,
-    CC_FULL,
-} CCTspinStatus;
-
 typedef enum CCMovement {
     CC_LEFT, CC_RIGHT,
     CC_CW, CC_CCW,
@@ -37,14 +27,6 @@ typedef enum CCBotPollStatus {
     CC_BOT_DEAD
 } CCBotPollStatus;
 
-typedef struct CCFallingPiece {
-    CCPiece piece;
-    CCRotationState state;
-    uint8_t expected_x[4];
-    uint8_t expected_y[4];
-    CCTspinStatus tspin;
-} CCFallingPiece;
-
 typedef enum CCPlacementKind {
     CC_NONE_PLACEMENT_KIND,
     CC_CLEAR1,
@@ -60,19 +42,12 @@ typedef enum CCPlacementKind {
     CC_TSPIN3
 } CCPlacementKind;
 
-typedef struct CCLockResult {
-    CCPlacementKind placement_kind;
-    bool locked_out;
-    bool b2b;
-    bool perfect_clear;
-    uint32_t combo;
-    uint32_t garbage_sent;
-    int32_t cleared_lines[4];
-} CCLockResult;
-
 typedef struct CCPlan {
-    CCFallingPiece falling_piece;
-    CCLockResult lock_result;
+    CCPiece piece;
+    uint8_t expected_x[4];
+    uint8_t expected_y[4];
+    CCPlacementKind placement_kind;
+    int32_t cleared_lines[4];
 } CCPlan;
 
 typedef struct CCMove {

--- a/c-api/coldclear.h
+++ b/c-api/coldclear.h
@@ -8,6 +8,17 @@ typedef enum CCPiece {
     CC_I, CC_T, CC_O, CC_S, CC_Z, CC_L, CC_J
 } CCPiece;
 
+typedef enum CCRotationState {
+    CC_NORTH, CC_SOUTH, CC_EAST, CC_WEST
+} CCRotationState;
+
+typedef enum CCTspinStatus {
+    CC_NONE_TSPIN_STATUS,
+    CC_MINI,
+    CC_FULL,
+    CC_PERSISTENT_FULL
+} CCTspinStatus;
+
 typedef enum CCMovement {
     CC_LEFT, CC_RIGHT,
     CC_CW, CC_CCW,
@@ -26,6 +37,44 @@ typedef enum CCBotPollStatus {
     CC_WAITING,
     CC_BOT_DEAD
 } CCBotPollStatus;
+
+typedef struct CCFallingPiece {
+    CCPiece piece;
+    CCRotationState state;
+    uint8_t expected_x[4];
+    uint8_t expected_y[4];
+    CCTspinStatus tspin;
+} CCFallingPiece;
+
+typedef enum CCPlacementKind {
+    CC_NONE_PLACEMENT_KIND,
+    CC_CLEAR1,
+    CC_CLEAR2,
+    CC_CLEAR3,
+    CC_CLEAR4,
+    CC_MINI_TSPIN,
+    CC_MINI_TSPIN1,
+    CC_MINI_TSPIN2,
+    CC_TSPIN,
+    CC_TSPIN1,
+    CC_TSPIN2,
+    CC_TSPIN3
+} CCPlacementKind;
+
+typedef struct CCLockResult {
+    CCPlacementKind placement_kind;
+    bool locked_out;
+    bool b2b;
+    bool perfect_clear;
+    uint32_t combo;
+    uint32_t garbage_sent;
+    int32_t cleared_lines[4];
+} CCLockResult;
+
+typedef struct CCPlan {
+    CCFallingPiece falling_piece;
+    CCLockResult lock_result;
+} CCPlan;
 
 typedef struct CCMove {
     /* Whether hold is required */
@@ -165,6 +214,13 @@ void cc_request_next_move(CCAsyncBot *bot, uint32_t incoming);
  */
 CCBotPollStatus cc_poll_next_move(CCAsyncBot *bot, CCMove *move);
 
+/* Same to cc_poll_next_move_with_plans, but also provide plans along with the next move.
+ * Caller is responsible for allocating space for array of CCPlan.
+ * The num_plans parameter is used for both input and output. Caller passes in the size of
+ * the allocated array, this function returns the number of plans actually provided.
+ */
+CCBotPollStatus cc_poll_next_move_with_plans(CCAsyncBot *bot, CCMove *move, CCPlan* plans, uint32_t *num_plans);
+
 /* This function is the same as `cc_poll_next_move` except when `cc_poll_next_move` would return
  * `CC_WAITING` it instead waits until the bot has made a decision.
  *
@@ -172,6 +228,13 @@ CCBotPollStatus cc_poll_next_move(CCAsyncBot *bot, CCMove *move);
  * If the bot has found that it cannot survive, this function will return `CC_BOT_DEAD`
  */
 CCBotPollStatus cc_block_next_move(CCAsyncBot *bot, CCMove *move);
+
+/* Same to cc_block_next_move, but also provide plans along with the next move.
+ * Caller is responsible for allocating space for array of CCPlan.
+ * The num_plans parameter is used for both input and output. Caller passes in the size of
+ * the allocated array, this function returns the number of plans actually provided.
+ */
+CCBotPollStatus cc_block_next_move_with_plans(CCAsyncBot *bot, CCMove *move, CCPlan* plans, uint32_t *num_plans);
 
 /* Returns the default options in the options parameter */
 void cc_default_options(CCOptions *options);

--- a/c-api/coldclear.h
+++ b/c-api/coldclear.h
@@ -8,6 +8,12 @@ typedef enum CCPiece {
     CC_I, CC_T, CC_O, CC_S, CC_Z, CC_L, CC_J
 } CCPiece;
 
+typedef enum CCTspinStatus {
+    CC_NONE_TSPIN_STATUS,
+    CC_MINI,
+    CC_FULL,
+} CCTspinStatus;
+
 typedef enum CCMovement {
     CC_LEFT, CC_RIGHT,
     CC_CW, CC_CCW,
@@ -27,26 +33,15 @@ typedef enum CCBotPollStatus {
     CC_BOT_DEAD
 } CCBotPollStatus;
 
-typedef enum CCPlacementKind {
-    CC_NONE_PLACEMENT_KIND,
-    CC_CLEAR1,
-    CC_CLEAR2,
-    CC_CLEAR3,
-    CC_CLEAR4,
-    CC_MINI_TSPIN,
-    CC_MINI_TSPIN1,
-    CC_MINI_TSPIN2,
-    CC_TSPIN,
-    CC_TSPIN1,
-    CC_TSPIN2,
-    CC_TSPIN3
-} CCPlacementKind;
-
 typedef struct CCPlan {
     CCPiece piece;
+    CCTspinStatus tspin;
+
+    /* Expected cell coordinates of placement, (0, 0) being the bottom left */
     uint8_t expected_x[4];
     uint8_t expected_y[4];
-    CCPlacementKind placement_kind;
+
+    /* Expected lines that will be cleared after placement. 0 being the bottom line, and -1 being not cleared */
     int32_t cleared_lines[4];
 } CCPlan;
 

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -49,19 +49,10 @@ cenum! {
         CC_J => J
     }
 
-    enum CCPlacementKind => libtetris::PlacementKind {
+    enum CCTspinStatus => libtetris::TspinStatus {
         CC_NONE => None,
-        CC_CLEAR1 => Clear1,
-        CC_CLEAR2 => Clear2,
-        CC_CLEAR3 => Clear3,
-        CC_CLEAR4 => Clear4,
-        CC_MINI_TSPIN => MiniTspin,
-        CC_MINI_TSPIN1 => MiniTspin1,
-        CC_MINI_TSPIN2 => MiniTspin2,
-        CC_TSPIN => Tspin,
-        CC_TSPIN1 => Tspin1,
-        CC_TSPIN2 => Tspin2,
-        CC_TSPIN3 => Tspin3
+        CC_MINI => Mini,
+        CC_FULL => Full
     }
 
     enum CCMovement => libtetris::PieceMovement {
@@ -105,9 +96,9 @@ struct CCMove {
 #[derive(Copy, Clone, Debug)]
 struct CCPlan {
     piece: CCPiece,
+    tspin: CCTspinStatus,
     expected_x: [u8; 4],
     expected_y: [u8; 4],
-    placement_kind: CCPlacementKind,
     cleared_lines: [i32; 4],
 }
 
@@ -243,16 +234,16 @@ fn convert_plan((falling_piece, lock_result): &(libtetris::FallingPiece, libtetr
         expected_y[i] = y as u8;
     }
 
-    let mut cleared_lines = [0; 4];
+    let mut cleared_lines = [-1; 4];
     for (i, &cl) in lock_result.cleared_lines.iter().enumerate() {
         cleared_lines[i] = cl;
     }
 
     CCPlan {
         piece: falling_piece.kind.0.into(),
+        tspin: falling_piece.tspin.into(),
         expected_x: expected_x,
         expected_y: expected_y,
-        placement_kind: lock_result.placement_kind.into(),
         cleared_lines: cleared_lines,
     }
 }

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -49,19 +49,6 @@ cenum! {
         CC_J => J
     }
 
-    enum CCRotationState => libtetris::RotationState {
-        CC_NORTH => North,
-        CC_SOUTH => South,
-        CC_EAST => East,
-        CC_WEST => West
-    }
-
-    enum CCTspinStatus => libtetris::TspinStatus {
-        CC_NONE => None,
-        CC_MINI => Mini,
-        CC_FULL => Full
-    }
-
     enum CCPlacementKind => libtetris::PlacementKind {
         CC_NONE => None,
         CC_CLEAR1 => Clear1,
@@ -116,31 +103,12 @@ struct CCMove {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-struct CCFallingPiece {
+struct CCPlan {
     piece: CCPiece,
-    state: CCRotationState,
     expected_x: [u8; 4],
     expected_y: [u8; 4],
-    tspin: CCTspinStatus,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-struct CCLockResult {
     placement_kind: CCPlacementKind,
-    locked_out: bool,
-    b2b: bool,
-    perfect_clear: bool,
-    combo: u32,
-    garbage_sent: u32,
     cleared_lines: [i32; 4],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-struct CCPlan {
-    falling_piece: CCFallingPiece,
-    lock_result: CCLockResult,
 }
 
 #[repr(C)]
@@ -275,33 +243,17 @@ fn convert_plan((falling_piece, lock_result): &(libtetris::FallingPiece, libtetr
         expected_y[i] = y as u8;
     }
 
-    let mut combos = 0 as u32;
-    if let Some(combo) = lock_result.combo {
-        combos = combo as u32;
-    }
-
     let mut cleared_lines = [0; 4];
     for (i, &cl) in lock_result.cleared_lines.iter().enumerate() {
         cleared_lines[i] = cl;
     }
 
     CCPlan {
-        falling_piece: CCFallingPiece{
-            piece: falling_piece.kind.0.into(),
-            state: falling_piece.kind.1.into(),
-            expected_x: expected_x,
-            expected_y: expected_y,
-            tspin: falling_piece.tspin.into(),
-        },
-        lock_result: CCLockResult{
-            placement_kind: lock_result.placement_kind.into(),
-            locked_out: lock_result.locked_out,
-            b2b: lock_result.b2b,
-            perfect_clear: lock_result.perfect_clear,
-            combo: combos,
-            garbage_sent: lock_result.garbage_sent,
-            cleared_lines: cleared_lines,
-        },
+        piece: falling_piece.kind.0.into(),
+        expected_x: expected_x,
+        expected_y: expected_y,
+        placement_kind: lock_result.placement_kind.into(),
+        cleared_lines: cleared_lines,
     }
 }
 


### PR DESCRIPTION
Add two parameters plans, num_plans to cc_poll_next_move and
cc_block_next_move. This will allow access to CC's placement plans.

Caller is responsible for allocating space for the plans and passing
correct size of array. The actually number of plans is returned in
the same parameter.