### PR TITLE
Allow c-api to start CC from existing board state

### DIFF
--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -13,3 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 cold-clear = { path = "../bot" }
 libtetris = { path = "../libtetris" }
+enumset = { version = "0.4.0"}

--- a/c-api/coldclear.h
+++ b/c-api/coldclear.h
@@ -118,6 +118,21 @@ typedef struct CCWeights {
  */
 CCAsyncBot *cc_launch_async(CCOptions *options, CCWeights *weights);
 
+/* Launches a bot thread with a predefined field, empty queue, remaining pieces in the bag, hold piece,
+ * back-to-back status, and combo count. This allows you to start CC from the middle of a game.
+ * 
+ * The bag_remain parameter is a bit field indicating which pieces are still in the bag. Each bit
+ * correspond to CCPiece enum. This must match the next few pieces provided to CC via
+ * cc_add_next_piece_async later.
+ * 
+ * The field parameter is a pointer to the start of an array of 400 booleans in row major order,
+ * with index 0 being the bottom-left cell.
+ * 
+ * The hold parameter is a pointer to the current hold piece, or `NULL` if there's no hold piece now.
+ */
+CCAsyncBot *cc_launch_with_board_async(CCOptions *options, CCWeights *weights, bool *field,
+    uint32_t bag_remain, CCPiece *hold, bool b2b, uint32_t combo);
+
 /* Terminates the bot thread and frees the memory associated with the bot.
  */
 void cc_destroy_async(CCAsyncBot *bot);

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -158,8 +158,7 @@ fn convert_hold(hold: *mut CCPiece) -> Option<libtetris::Piece> {
     if hold.is_null() {
         None
     } else {
-        let h = unsafe {*hold};
-        Some(h.into())
+        Some(unsafe{*hold}.into())
     }
 }
 

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -1,4 +1,5 @@
 use std::mem::MaybeUninit;
+use enumset::EnumSet;
 
 type CCAsyncBot = cold_clear::Interface;
 
@@ -219,7 +220,7 @@ fn convert_from_c_weights(weights: &CCWeights) -> cold_clear::evaluation::Standa
 extern "C" fn cc_launch_with_board_async(options: &CCOptions, weights: &CCWeights, field: &[[bool; 10]; 40], 
     bag_remain: u32, hold: *mut CCPiece, b2b: bool, combo: u32) -> *mut CCAsyncBot {
     Box::into_raw(Box::new(cold_clear::Interface::launch(
-        libtetris::Board::new_from_exist_board(*field, bag_remain, convert_hold(hold), b2b, combo),
+        libtetris::Board::new_with_state(*field, EnumSet::from_bits(bag_remain as u128), convert_hold(hold), b2b, combo),
         convert_from_c_options(options),
         convert_from_c_weights(weights)
     )))

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -153,56 +153,84 @@ struct CCWeights {
     use_bag: bool,
 }
 
+fn convert_hold(hold: *mut CCPiece) -> Option<libtetris::Piece> {
+    if hold.is_null() {
+        None
+    } else {
+        let h = unsafe {*hold};
+        Some(h.into())
+    }
+}
+
+
+fn convert_from_c_options(options: &CCOptions) -> cold_clear::Options {
+    cold_clear::Options {
+        max_nodes: options.max_nodes,
+        min_nodes: options.min_nodes,
+        use_hold: options.use_hold,
+        speculate: options.speculate,
+        pcloop: options.pcloop,
+        mode: options.mode.into(),
+        threads: options.threads
+    }
+}
+
+fn convert_from_c_weights(weights: &CCWeights) -> cold_clear::evaluation::Standard {
+    cold_clear::evaluation::Standard {
+        back_to_back: weights.back_to_back,
+        bumpiness: weights.bumpiness,
+        bumpiness_sq: weights.bumpiness_sq,
+        height: weights.height,
+        top_half: weights.top_half,
+        top_quarter: weights.top_quarter,
+        jeopardy: weights.jeopardy,
+        cavity_cells: weights.cavity_cells,
+        cavity_cells_sq: weights.cavity_cells_sq,
+        overhang_cells: weights.overhang_cells,
+        overhang_cells_sq: weights.overhang_cells_sq,
+        covered_cells: weights.covered_cells,
+        covered_cells_sq: weights.covered_cells_sq,
+        tslot: weights.tslot,
+        well_depth: weights.well_depth,
+        max_well_depth: weights.max_well_depth,
+        well_column: weights.well_column,
+
+        b2b_clear: weights.b2b_clear,
+        clear1: weights.clear1,
+        clear2: weights.clear2,
+        clear3: weights.clear3,
+        clear4: weights.clear4,
+        tspin1: weights.tspin1,
+        tspin2: weights.tspin2,
+        tspin3: weights.tspin3,
+        mini_tspin1: weights.mini_tspin1,
+        mini_tspin2: weights.mini_tspin2,
+        perfect_clear: weights.perfect_clear,
+        combo_garbage: weights.combo_garbage,
+        move_time: weights.move_time,
+        wasted_t: weights.wasted_t,
+
+        use_bag: weights.use_bag,
+        sub_name: None
+    }
+}
+
+#[no_mangle]
+extern "C" fn cc_launch_with_board_async(options: &CCOptions, weights: &CCWeights, field: &[[bool; 10]; 40], 
+    bag_remain: u32, hold: *mut CCPiece, b2b: bool, combo: u32) -> *mut CCAsyncBot {
+    Box::into_raw(Box::new(cold_clear::Interface::launch(
+        libtetris::Board::new_from_exist_board(*field, bag_remain, convert_hold(hold), b2b, combo),
+        convert_from_c_options(options),
+        convert_from_c_weights(weights)
+    )))
+}
+
 #[no_mangle]
 extern "C" fn cc_launch_async(options: &CCOptions, weights: &CCWeights) -> *mut CCAsyncBot {
     Box::into_raw(Box::new(cold_clear::Interface::launch(
         libtetris::Board::new(),
-        cold_clear::Options {
-            max_nodes: options.max_nodes,
-            min_nodes: options.min_nodes,
-            use_hold: options.use_hold,
-            speculate: options.speculate,
-            pcloop: options.pcloop,
-            mode: options.mode.into(),
-            threads: options.threads
-        },
-        cold_clear::evaluation::Standard {
-            back_to_back: weights.back_to_back,
-            bumpiness: weights.bumpiness,
-            bumpiness_sq: weights.bumpiness_sq,
-            height: weights.height,
-            top_half: weights.top_half,
-            top_quarter: weights.top_quarter,
-            jeopardy: weights.jeopardy,
-            cavity_cells: weights.cavity_cells,
-            cavity_cells_sq: weights.cavity_cells_sq,
-            overhang_cells: weights.overhang_cells,
-            overhang_cells_sq: weights.overhang_cells_sq,
-            covered_cells: weights.covered_cells,
-            covered_cells_sq: weights.covered_cells_sq,
-            tslot: weights.tslot,
-            well_depth: weights.well_depth,
-            max_well_depth: weights.max_well_depth,
-            well_column: weights.well_column,
-
-            b2b_clear: weights.b2b_clear,
-            clear1: weights.clear1,
-            clear2: weights.clear2,
-            clear3: weights.clear3,
-            clear4: weights.clear4,
-            tspin1: weights.tspin1,
-            tspin2: weights.tspin2,
-            tspin3: weights.tspin3,
-            mini_tspin1: weights.mini_tspin1,
-            mini_tspin2: weights.mini_tspin2,
-            perfect_clear: weights.perfect_clear,
-            combo_garbage: weights.combo_garbage,
-            move_time: weights.move_time,
-            wasted_t: weights.wasted_t,
-
-            use_bag: weights.use_bag,
-            sub_name: None
-        }
+        convert_from_c_options(options),
+        convert_from_c_weights(weights)
     )))
 }
 

--- a/libtetris/src/board.rs
+++ b/libtetris/src/board.rs
@@ -43,7 +43,7 @@ impl<R: Row> Board<R> {
     }
 
     /// Creates a blank board with an empty queue.
-    pub fn new_from_exist_board(field: [[bool; 10]; 40], bag_remain: u32, hold: Option<Piece>, b2b: bool, combo: u32) -> Self {
+    pub fn new_with_state(field: [[bool; 10]; 40], bag_remain: EnumSet<Piece>, hold: Option<Piece>, b2b: bool, combo: u32) -> Self {
         let mut board = Board {
             cells: [*R::EMPTY; 40].into(),
             column_heights: [0; 10],
@@ -51,7 +51,7 @@ impl<R: Row> Board<R> {
             b2b_bonus: b2b,
             hold_piece: hold,
             next_pieces: VecDeque::new(),
-            bag: EnumSet::from_bits(bag_remain as u128),
+            bag: bag_remain,
         };
         board.set_field(field);
         board

--- a/libtetris/src/board.rs
+++ b/libtetris/src/board.rs
@@ -42,7 +42,7 @@ impl<R: Row> Board<R> {
         }
     }
 
-    /// Creates a blank board with an empty queue.
+    /// Creates a board with existing field, remain pieces in the bag, hold piece, back-to-back status and combo count.
     pub fn new_with_state(field: [[bool; 10]; 40], bag_remain: EnumSet<Piece>, hold: Option<Piece>, b2b: bool, combo: u32) -> Self {
         let mut board = Board {
             cells: [*R::EMPTY; 40].into(),

--- a/libtetris/src/board.rs
+++ b/libtetris/src/board.rs
@@ -42,6 +42,21 @@ impl<R: Row> Board<R> {
         }
     }
 
+    /// Creates a blank board with an empty queue.
+    pub fn new_from_exist_board(field: [[bool; 10]; 40], bag_remain: u32, hold: Option<Piece>, b2b: bool, combo: u32) -> Self {
+        let mut board = Board {
+            cells: [*R::EMPTY; 40].into(),
+            column_heights: [0; 10],
+            combo: combo,
+            b2b_bonus: b2b,
+            hold_piece: hold,
+            next_pieces: VecDeque::new(),
+            bag: EnumSet::from_bits(bag_remain as u128),
+        };
+        board.set_field(field);
+        board
+    }
+
     /// Randomly selects a piece from the bag.
     /// 
     /// This function does not remove the generated piece from the bag.


### PR DESCRIPTION
Currently there's no c-api to start CC from the middle of a game,
because cc_reset_async doesn't support resetting hold piece, and
more importantly the bag status.

Add cc_launch_with_board_async to start CC from existing game state,
including board field, hold piece, remaining piece in bag, b2b and
combo status. If speculation is enabled, setting correct bag status
is critical otherwise CC just die randomly due to broken speculation
machine.

This enables client program to handle mishold gracefully. Also makes
it easier to load existing fumen and start CC.