### PR TITLE
Add PcPriority to dummy pcloop module to fix compilation on wasm32

### DIFF
--- a/bot/src/modes/mod.rs
+++ b/bot/src/modes/mod.rs
@@ -247,4 +247,10 @@ pub mod pcloop {
     pub struct Info {
         pub plan: Vec<(FallingPiece, LockResult)>
     }
+
+    #[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
+    pub enum PcPriority {
+        Fastest,
+        HighestAttack,
+    }
 }


### PR DESCRIPTION
Fixes `wasm32-unknown-unknown` compilation errors in a similar manner as commit d10525d. The repetition of both the `Info` and `PcPriority` types might mean a refactor of how the dummy types work is in order, though...